### PR TITLE
Updated for TF v0.13

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.12"
 }


### PR DESCRIPTION
To not execute the "terraform 0.13upgrade -yes" command during TF v0.13 upgrade